### PR TITLE
Updates the schema with status default value of 0

### DIFF
--- a/db/migrate/20221105045319_remove_and_add_status_to_items.rb
+++ b/db/migrate/20221105045319_remove_and_add_status_to_items.rb
@@ -1,0 +1,6 @@
+class RemoveAndAddStatusToItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :status
+    add_column :items, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_04_004209) do
+ActiveRecord::Schema.define(version: 2022_11_05_045319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_004209) do
     t.integer "unit_price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "status"
+    t.integer "status", default: 0
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 


### PR DESCRIPTION
- Items table in the database had a status column with a default value of NULL
- this merge will change the schema via migration by adding a default value of 0
- this was achieved by dropping the status column without a default value an adding the status column with a default value of 0